### PR TITLE
Make it more `print` like to easy change prints

### DIFF
--- a/igcolors/__init__.py
+++ b/igcolors/__init__.py
@@ -28,8 +28,10 @@ version of the original color on most terminals.
 
 def _wrap_with(code):
 
-    def inner(text, light=False, bold=False, dim=False, underline=False,
-              blink=False, reverse=False, hidden=False):
+    def inner(*args, sep=' ', light=False, bold=False, dim=False,
+              underline=False, blink=False, reverse=False, hidden=False):
+        text = sep.join(args)
+
         c = code
         if light:
             c = str(int(c)+60)


### PR DESCRIPTION
Print function support a spelling like that:
``` python
print('some', 'thing')
```
to print ‘some thing’.  To make that red e.g. one has to concatenate
the strings first like that:
``` python
print(red('some thing'))
```

With that it is now possible to easily write it like that:
``` python
print(red('some', 'thing'))
```

It also supports to change the separator then, just like the `print`
function:
``` python
print(red('some', 'thing', sep=', '))
# Output: 'some, thing'
```